### PR TITLE
Fix wrong regexp

### DIFF
--- a/rule.json
+++ b/rule.json
@@ -5,11 +5,11 @@
         "action" : { 
             "type" : "redirect",
             "redirect" : {
-                "regexSubstitution": "https://zh.wikipedia.org/zh-cn/"
+                "regexSubstitution": "https://zh.wikipedia.org/wiki/"
             }
         },
         "condition" : {
-            "regexFilter": "^https://zh.*.wikipedia.org/.*/",
+            "regexFilter": "https?://zh\.(?:m\.)?wikipedia.org/zh[a-zA-Z\-]*?/",
             "resourceTypes": ["main_frame"]
         }
     }

--- a/rule.json
+++ b/rule.json
@@ -9,7 +9,7 @@
             }
         },
         "condition" : {
-            "regexFilter": "https?://zh\.(?:m\.)?wikipedia.org/zh[a-zA-Z\-]*?/",
+            "regexFilter": "https?://zh\\.(?:m\\.)?wikipedia.org/zh[\\w\\-]*?/",
             "resourceTypes": ["main_frame"]
         }
     }


### PR DESCRIPTION
Using `wiki` in the URL will cause a fallback to the user's personal settings and thus browser settings, which is usually what the user wants.

The original RegExp was so terrible that many URLs would be incorrectly matched, such as:

- `https://zh.wikipedia.org/wiki/User:Sample/Sandbox`
- `https://zh.wikipedia.org/w/api.php?action=parse`
- `https://zh.wikipedia.org/w/api.php?text=zh.wikipedia.org/w/sample`
- ......